### PR TITLE
Upgrades

### DIFF
--- a/src/docking_scenarios/refinement-protocols.md
+++ b/src/docking_scenarios/refinement-protocols.md
@@ -63,7 +63,7 @@ molecules = "model_1.pdb"
 [openmm]
 # Define the timesteps
 timestep_ps = 0.002  # default parameter
-# Increase the simulation timesteps (500000 * 0.002 = 10 ns)
+# Increase the simulation timesteps (5000000 * 0.002 ps = 10000 ps = 10 ns)
 simulation_timesteps = 5000000
 # Save 100 intermediate frames
 save_intermediate = 100

--- a/src/flexibility.md
+++ b/src/flexibility.md
@@ -110,6 +110,11 @@ seg_sta_1_2 = 22
 seg_end_1_2 = 39
 ```
 
+Check out schematic images of the refinement protocols employed in different [refinements modules](./modules/refinement.md):
+* [`[flexref]`](./modules/refinement.md#flexref-module-simulated-annealing-protocol-scheme)
+* [`[mdref]`](./modules/refinement.md#mdref-module-scheme)
+* [`[emref]`](./modules/refinement.md#emref-module-scheme)
+
 ### Fully flexible Segment
 
 Fully Flexible Segment
@@ -150,3 +155,8 @@ fle_sta_1 = 1
 # Define the last residue for the 1st fully flexible segment 
 fle_end_1 = 4
 ```
+
+Check out schematic images of the refinement protocols employed in different [refinements modules](./modules/refinement.md):
+* [`[flexref]`](./modules/refinement.md#flexref-module-simulated-annealing-protocol-scheme)
+* [`[mdref]`](./modules/refinement.md#mdref-module-scheme)
+* [`[emref]`](./modules/refinement.md#emref-module-scheme)

--- a/src/modules/analysis.md
+++ b/src/modules/analysis.md
@@ -145,7 +145,7 @@ A detailed tutorial on this specific case is available [here](https://www.bonvin
 
 Example application of the ``[clustrmsd]`` module:
 - after performing rigid-body docking
-- computes the RMSD matrix, focused on a particular set of residues from chain A and B
+- compute the RMSD matrix, focusing on a particular set of residues from chains A and B
 - apply RMSD-based clustering to the matrix to obtain **50** clusters
 
 Here is the corresponding configuration file example that corresponds to the above sequence of modules:

--- a/src/modules/analysis.md
+++ b/src/modules/analysis.md
@@ -232,9 +232,9 @@ As all the pairwise ilRMSD calculations are independent, the module distributes
 them over all the available cores in an optimal way.
 
 **IMPORTANT**:
-- the module assumes coherent numbering for all the receptor and ligand
-chains, as no sequence alignment is performed. The user must ensure that the numbering
-is coherent.
+- the module assumes coherent numbering for all the receptor and ligand chains,
+as no sequence alignment is performed. The user must ensure that the numbering
+is coherent (same chains, same sequences and residue ids accross all models).
 - this module is **only** computing the interface-ligand-RMSD matrix, but does not
 perform any kind of clustering. To perform RMSD clustering, one should first run
 this module, then use the [`[clustrmsd]` module](#clustrmsd-module).
@@ -278,9 +278,9 @@ As all the pairwise RMSD calculations are independent, the module distributes
 them over all the available cores in an optimal way.
 
 **IMPORTANT**:
-- the module assumes coherent numbering for all the receptor and ligand
-chains, as no sequence alignment is performed. The user must ensure that the numbering
-is coherent.
+- the module assumes coherent numbering for all the receptor and ligand chains,
+as no sequence alignment is performed. The user must ensure that the numbering
+is coherent (same chains, same sequences and residue ids accross all models).
 - this module is **only** computing the RMSD matrix, but does not
 perform any kind of clustering. To perform RMSD clustering, one should first run
 this module, then use the [`[clustrmsd]` module](#clustrmsd-module).

--- a/src/modules/analysis.md
+++ b/src/modules/analysis.md
@@ -139,13 +139,14 @@ progressively coarser hierarchy of clusters, called the dendrogram.
 Typically, the module is run at the end of a protein-small molecule docking protocol to cluster the
 models and identify the best clusters. In these workflows, ``[clustrmsd]`` is more appropriate than ``[clustfcc]`` 
 as most models will share a consistent fraction of contacts, while still being structurally different.
-In [this paper](https://www.biorxiv.org/content/10.1101/2024.07.31.605986v1), we show that, in the context of protein-glycan docking, RMSD clustering performed after 
-``[rigidbody]`` docking increases the success rate. A detailed tutorial on this specific case is available [here](https://www.bonvinlab.org/education/HADDOCK3/HADDOCK3-protein-glycan/).
+In [this paper](https://pubs.acs.org/doi/10.1021/acs.jcim.4c01372)([BioRxiv](https://www.biorxiv.org/content/10.1101/2024.07.31.605986v1)),
+we show that, in the context of protein-glycan docking, RMSD clustering performed after ``[rigidbody]`` docking increases the success rate.
+A detailed tutorial on this specific case is available [here](https://www.bonvinlab.org/education/HADDOCK3/HADDOCK3-protein-glycan/).
 
 Example application of the ``[clustrmsd]`` module:
-- after rigid-body docking
-- computes the RMSDmatrix
-- then cluster the matrix into 50 clusters
+- after performing rigid-body docking
+- computes the RMSD matrix, focused on a particular set of residues from chain A and B
+- apply RMSD-based clustering to the matrix to obtain **50** clusters
 
 Here is the corresponding configuration file example that corresponds to the above sequence of modules:
 

--- a/src/modules/analysis.md
+++ b/src/modules/analysis.md
@@ -130,7 +130,7 @@ The most important parameters for the ``[clustfcc]`` module are:
 
 RMSD clustering module.
 
-This module takes in input the [RMSD](#rmsdmatrix-module) (or the [ILRMSD](#ilrmsdmatrix-module)) matrix calculated in the previous step and
+This module takes in input the [RMSD](#rmsdmatrix-module) (or the [ILRMSD](#ilrmsdmatrix-module)) matrix **calculated in the previous step** and
 performs a hierarchical clustering procedure on it, leveraging [scipy routines](https://docs.scipy.org/doc/scipy/reference/cluster.hierarchy.html) for this purpose.
 
 Essentially, the procedure amounts at lumping the input models in a
@@ -142,12 +142,17 @@ as most models will share a consistent fraction of contacts, while still being s
 In [this paper](https://www.biorxiv.org/content/10.1101/2024.07.31.605986v1), we show that, in the context of protein-glycan docking, RMSD clustering performed after 
 ``[rigidbody]`` docking increases the success rate. A detailed tutorial on this specific case is available [here](https://www.bonvinlab.org/education/HADDOCK3/HADDOCK3-protein-glycan/).
 
-Example application of the ``[clustrmsd]`` module after rigid-body docking, retrieving 50 clusters:
+Example application of the ``[clustrmsd]`` module:
+- after rigid-body docking
+- computes the RMSDmatrix
+- then cluster the matrix into 50 clusters
+
+Here is the corresponding configuration file example that corresponds to the above sequence of modules:
 
 ```toml
 # ...
 [rigidbody]
-ambig_fname = ambiguous_restraints.tbl
+ambig_fname = "ambiguous_restraints.tbl"
 [rmsdmatrix]
 resdic_A = [1,2,3,4]
 resdic_B = [2,3,4,5]
@@ -225,9 +230,13 @@ the models generated in the previous step.
 As all the pairwise ilRMSD calculations are independent, the module distributes
 them over all the available cores in an optimal way.
 
-**IMPORTANT**: the module assumes coherent numbering for all the receptor and ligand
+**IMPORTANT**:
+- the module assumes coherent numbering for all the receptor and ligand
 chains, as no sequence alignment is performed. The user must ensure that the numbering
 is coherent.
+- this module is **only** computing the interface-ligand-RMSD matrix, but does not
+perform any kind of clustering. To perform RMSD clustering, one should first run
+this module, then use the [`[clustrmsd]` module](#clustrmsd-module).
 
 #### Notable parameters
 
@@ -267,11 +276,16 @@ generated in the previous step.
 As all the pairwise RMSD calculations are independent, the module distributes
 them over all the available cores in an optimal way.
 
-**IMPORTANT**: the module assumes coherent numbering for all the receptor and ligand
+**IMPORTANT**:
+- the module assumes coherent numbering for all the receptor and ligand
 chains, as no sequence alignment is performed. The user must ensure that the numbering
 is coherent.
+- this module is **only** computing the RMSD matrix, but does not
+perform any kind of clustering. To perform RMSD clustering, one should first run
+this module, then use the [`[clustrmsd]` module](#clustrmsd-module).
 
 #### Notable parameters
+
 - `allatoms`: whether to use all the atoms for the ILRMSD calculation (default: False)
 - `resdic_` : an expandable parameter to specify which residues must be
  considered for the alignment and the RMSD calculation. If there are


### PR DESCRIPTION
This PR provides some upgrades on the documentation, by:
- adding links to schematic representations to modules involved in semi-flexibility and flexibility
- specifying that `[ilrmsdmatrix]` and `[rmsdmatrix]` modules do not perform clustering