### PR TITLE
Add list of supported particles and update relevant links

### DIFF
--- a/src/bpg/dna.md
+++ b/src/bpg/dna.md
@@ -6,7 +6,7 @@
 
 <p style='text-align: right; font-family: "PT Sans"; font-weight: 600;'> <font  size="6" color="RED" >Best practice guide</font></p>
 
-HADDOCK supports the docking of nucleic acids, including both DNA and RNA. Currently, only canonical nucleic acid bases are supported. They are listed [here](https://wenmr.science.uu.nl/haddock2.4/library).
+HADDOCK supports the docking of nucleic acids, including both DNA and RNA. Currently, only canonical nucleic acid bases are supported. They are listed [here](./supported_particles.md#supported-nucleic-acid-bases).
 
 <hr>
 

--- a/src/bpg/dna.md
+++ b/src/bpg/dna.md
@@ -6,7 +6,7 @@
 
 <p style='text-align: right; font-family: "PT Sans"; font-weight: 600;'> <font  size="6" color="RED" >Best practice guide</font></p>
 
-HADDOCK supports the docking of nucleic acids, including both DNA and RNA. Currently, only canonical nucleic acid bases are supported. They are listed [here](./supported_particles.md#supported-nucleic-acid-bases).
+HADDOCK supports the docking of nucleic acids, including both DNA and RNA. Currently, only canonical nucleic acid bases are supported. They are listed [here](../supported_particles.md#supported-nucleic-acid-bases).
 
 <hr>
 

--- a/src/bpg/glycans.md
+++ b/src/bpg/glycans.md
@@ -6,7 +6,7 @@
 
 <p style='text-align: right; font-family: "PT Sans"; font-weight: 600;'> <font  size="6" color="RED" >Best practice guide</font></p>
 
-HADDOCK also supports the docking of several carbohydrates.sa A list of glycan residues supported by HADDOCK can be found [here](./supported_particles.md). 
+HADDOCK also supports the docking of several carbohydrates. A list of glycan residues supported by HADDOCK can be found [here](../supported_particles.md). 
 
 This page consists of the following chapters:
 

--- a/src/bpg/glycans.md
+++ b/src/bpg/glycans.md
@@ -6,8 +6,9 @@
 
 <p style='text-align: right; font-family: "PT Sans"; font-weight: 600;'> <font  size="6" color="RED" >Best practice guide</font></p>
 
-HADDOCK also supports the docking of several carbohydrates.
-A list of glycan residues supported by HADDOCK can be found [here](https://wenmr.science.uu.nl/haddock2.4/library). This page consists of the following chapters:
+HADDOCK also supports the docking of several carbohydrates.sa A list of glycan residues supported by HADDOCK can be found [here](./supported_particles.md). 
+
+This page consists of the following chapters:
 
 
 <hr>

--- a/src/bpg/structures.md
+++ b/src/bpg/structures.md
@@ -86,7 +86,7 @@ To prevent this, try to energy minimize the structure and remove *spaghetti* aro
 * [Rosetta](https://www.rosettacommons.org/docs/latest/application_documentation/utilities/build-peptide)
     * Rosetta, as well as plenty of other online tools have now functionalities with which you can build peptides from their sequences.  
 
-* A list of modified amino acids supported by HADDOCK can be found [here](https://wenmr.science.uu.nl/haddock2.4/library).
+* A list of modified amino acids supported by HADDOCK can be found [here](./supported_particles.md#supported-modified-amino-acids).
 
 
 #### Modeling of small molecules 
@@ -177,7 +177,7 @@ Tutorials:
 
 * [Haddock tools](https://github.com/haddocking/haddock-tools) are a bunch of useful tools available on [Github](https://github.com/haddocking/haddock-tools for use with local version of HADDOCK) that can be used to modify pdb or restraint files.
 
-* A list of modified amino acids and other molecule types supported by HADDOCK can be found [here](https://wenmr.science.uu.nl/haddock2.4/library).
+* A list of modified amino acids and other particle types supported by HADDOCK can be found [here](./supported_particles.md).
 
 
 <hr>

--- a/src/bpg/structures.md
+++ b/src/bpg/structures.md
@@ -86,7 +86,7 @@ To prevent this, try to energy minimize the structure and remove *spaghetti* aro
 * [Rosetta](https://www.rosettacommons.org/docs/latest/application_documentation/utilities/build-peptide)
     * Rosetta, as well as plenty of other online tools have now functionalities with which you can build peptides from their sequences.  
 
-* A list of modified amino acids supported by HADDOCK can be found [here](./supported_particles.md#supported-modified-amino-acids).
+* A list of modified amino acids supported by HADDOCK can be found [here](../supported_particles.md#supported-modified-amino-acids).
 
 
 #### Modeling of small molecules 
@@ -177,7 +177,7 @@ Tutorials:
 
 * [Haddock tools](https://github.com/haddocking/haddock-tools) are a bunch of useful tools available on [Github](https://github.com/haddocking/haddock-tools for use with local version of HADDOCK) that can be used to modify pdb or restraint files.
 
-* A list of modified amino acids and other particle types supported by HADDOCK can be found [here](./supported_particles.md).
+* A list of modified amino acids and other particle types supported by HADDOCK can be found [here](../supported_particles.md).
 
 
 <hr>

--- a/src/faq.md
+++ b/src/faq.md
@@ -19,7 +19,7 @@ If your problem falls outside of the topics, please see the [Getting support / H
 
 ## What about missing atoms?
 
-Missing atoms will be automatically detected (if part of the [HADDOCK library](https://wenmr.science.uu.nl/haddock2.4/library)) and re-generated when running the [`[topoaa]` module](./modules/topology.md#topoaa-module).
+Missing atoms will be automatically detected (if residues with these missing atoms is in the list of [supported particles](./supported_particles.md)) and re-generated when running the [`[topoaa]` module](./modules/topology.md#topoaa-module).
 For this reason, it is always used as the first module in a haddock3 workflow configuration file, not only to generate the topology of the input molecules but also to add and reconstruct missing atoms.
 
 <hr>
@@ -46,7 +46,7 @@ The extra/missing atoms will be automatically detected and the corrected topolog
 It is important to have at least the backbone atoms and at least the CB atom along the side-chain defined since their average position will be used as a starting point to "grow" the missing atoms.
 Always check that the sequence of the various PDB files matches!
 
-**Note** that this approach is only functional for residues supported in the [HADDOCK library](https://wenmr.science.uu.nl/haddock2.4/library).
+**Note** that this approach is only functional for residues supported in the [supported particles list](./supported_particles.md).
 
 <hr>
 
@@ -54,7 +54,7 @@ Always check that the sequence of the various PDB files matches!
 
 Some proteins contain ions such as for example calcium.
 Their inclusion might be important for docking purposes, in particular for proper electrostatics!
-In principle, they should be recognized when running the [`[topoaa]` module](./modules/topology.md#topoaa-module), provided their name in the PDB file matches the ion names in the list of supported ions (can be found [here](https://wenmr.science.uu.nl/haddock2.4/library)).
+In principle, they should be recognized when running the [`[topoaa]` module](./modules/topology.md#topoaa-module), provided their name in the PDB file matches the ion names in the list of [supported ions](./supported_particles.md#supported-ions)..
 
 <hr>
 
@@ -298,9 +298,8 @@ This can come from multiple reasons:
 
 If `100.00% of output was not generated`, there is probably an issue with the input molecules:
 
-- unrecognized amino acids
-- missing parameters/topology for residues outside of the [HADDOCK library](https://wenmr.science.uu.nl/haddock2.4/library)
-- huge sterical clashes
+- unrecognized amino acids or missing parameters/topology for residues outside of the [supported particles list](./supported_particles.md).
+- huge sterical clash
 
 If the value is inferior to `100.00%`, it can come from either one of the input conformers or a random error from the molecular dynamic simulation.
 In this case, you could increase the tolerance threshold to a higher value (e.g.: `tolerance = 10`), for the workflow to continue, as missing a few models can be acceptable.

--- a/src/faq.md
+++ b/src/faq.md
@@ -19,7 +19,7 @@ If your problem falls outside of the topics, please see the [Getting support / H
 
 ## What about missing atoms?
 
-Missing atoms will be automatically detected (if residues with these missing atoms is in the list of [supported particles](./supported_particles.md)) and re-generated when running the [`[topoaa]` module](./modules/topology.md#topoaa-module).
+Missing atoms will be automatically detected (if residues with these missing atoms are in the list of [supported particles](./supported_particles.md)) and re-generated when running the [`[topoaa]` module](./modules/topology.md#topoaa-module).
 For this reason, it is always used as the first module in a haddock3 workflow configuration file, not only to generate the topology of the input molecules but also to add and reconstruct missing atoms.
 
 <hr>
@@ -46,7 +46,7 @@ The extra/missing atoms will be automatically detected and the corrected topolog
 It is important to have at least the backbone atoms and at least the CB atom along the side-chain defined since their average position will be used as a starting point to "grow" the missing atoms.
 Always check that the sequence of the various PDB files matches!
 
-**Note** that this approach is only functional for residues supported in the [supported particles list](./supported_particles.md).
+**Note** that this approach is only functional for residues [supported](./supported_particles.md) by HADDOCK.
 
 <hr>
 
@@ -54,7 +54,7 @@ Always check that the sequence of the various PDB files matches!
 
 Some proteins contain ions such as for example calcium.
 Their inclusion might be important for docking purposes, in particular for proper electrostatics!
-In principle, they should be recognized when running the [`[topoaa]` module](./modules/topology.md#topoaa-module), provided their name in the PDB file matches the ion names in the list of [supported ions](./supported_particles.md#supported-ions)..
+In principle, they should be recognized when running the [`[topoaa]` module](./modules/topology.md#topoaa-module), provided their names in the PDB file matches the ion names in the list of [supported ions](./supported_particles.md#supported-ions).
 
 <hr>
 
@@ -298,7 +298,7 @@ This can come from multiple reasons:
 
 If `100.00% of output was not generated`, there is probably an issue with the input molecules:
 
-- unrecognized amino acids or missing parameters/topology for residues outside of the [supported particles list](./supported_particles.md).
+- unrecognized amino acids or missing parameters/topology for residues outside of the [supported particles list](./supported_particles.md)
 - huge sterical clash
 
 If the value is inferior to `100.00%`, it can come from either one of the input conformers or a random error from the molecular dynamic simulation.

--- a/src/modules/topology.md
+++ b/src/modules/topology.md
@@ -22,7 +22,7 @@ More information about `[topoaa]` parameters can be accessed [here](https://bonv
 haddock3-cfg -m topoaa
 ```
 
-HADDOCK supports a broad range of biomolecules and modified residues, [see Supported particles section](./supported_particles.md) for more details.
+HADDOCK supports a broad range of biomolecules and modified residues, [see Supported particles section](../supported_particles.md) for more details.
 For not supported molecules, HADDOCK will try to automatically generate the topology and parameters using PRODRG, if `autotoppar = true` is set in the `[topoaa]` module.
 Otherwise, you will have to provide the topology and parameters yourself, see [Dealing with non-standard molecules](#dealing-with-non-standard-molecules) section for more details.
 

--- a/src/modules/topology.md
+++ b/src/modules/topology.md
@@ -16,13 +16,15 @@ This module is a prerequisite to run any downstream modules using CNS.
 Having access to parameters and topology is mandatory for any kind of EM/MD related tasks.
 Therefore this is the reason why the module `[topoaa]` is often used as first module in a workflow.
 
-Note that for non-standard bio-molecules (apart from standard amino-acids, some modified ones, DNA, RNA, ions and carbohydrates ... see [detailed list of supported molecules](https://wenmr.science.uu.nl/haddock2.4/library)), such as small-molecules, parameters and topology must be obtained and provided by the user, as there is currently no built-in solution to generate them on the fly.
-
 More information about `[topoaa]` parameters can be accessed [here](https://bonvinlab.org/haddock3/src/modules/topology/haddock.modules.topology.topoaa.html#default-parameters) or retrieved by running:
 
 ```bash
 haddock3-cfg -m topoaa
 ```
+
+HADDOCK supports a broad range of biomolecules and modified residues, [see Supported particles section](./supported_particles.md) for more details.
+For not supported molecules, HADDOCK will try to automatically generate the topology and parameters using PRODRG, if `autotoppar = true` is set in the `[topoaa]` module.
+Otherwise, you will have to provide the topology and parameters yourself, see [Dealing with non-standard molecules](#dealing-with-non-standard-molecules) section for more details.
 
 Here an example configuration file snapshot of a typical execution of the
 `[topoaa]` module in which a user specifies the protonation state of the histidine

--- a/src/structure_requirements.md
+++ b/src/structure_requirements.md
@@ -1,9 +1,9 @@
 # Input files
 
 Over the years, HADDOCK was updated to increase the range of biomolecular entities to deal with.
-Currently, we support a broad range of molecular types, such as protein, DNA, RNA, glycans, cyclic-peptides and small-molecules.
-In addition, several modified residues/nucleotides are also available.
-For the full list of supported molecules, please refer to [https://wenmr.science.uu.nl/haddock2.4/library](https://wenmr.science.uu.nl/haddock2.4/library).
+Currently, we support a broad range of molecular types, such as protein, DNA, RNA, glycans, cyclic-peptides and small molecules.
+In addition, several modified amino acids are supported.
+For the full list of supported biomolecular entities, please refer to the [Supported particles section](./supported_particles.md).
 If you wish to work with a molecule type that is not present in this list, please refer to the [Dealing with non-standard molecules section](#dealing-with-non-standard-molecules).
 
 In the following sections, we will tackle the variety and specificity of each of the molecule types.
@@ -43,12 +43,12 @@ There are a few points to pay attention to when preparing the PDBs for HADDOCK.
  Its default behavior is to only keep the first (`A`) conformation, but you can select other conformations if wanted.
 
 * HADDOCK can deal with ions.
- You will have however to make sure that the ion naming is consistent with the ion [topologies provided in HADDOCK](https://wenmr.science.uu.nl/haddock2.4/library).
+ You will have however to make sure that the ion naming is consistent with the ion [topologies provided in HADDOCK](./supported_particles.md#supported-ions).
  For example, a CA heteroatom with a residue name CA will be interpreted as a neutral calcium atom.
  A doubly charged calcium ion should be named CA+2 with CA2 as residue name to be properly recognized by HADDOCK.
  (See also the [FAQ](./faq.md) for docking in the presence of ions).
 
-A list of [supported modified amino acids and ions is available online](https://wenmr.science.uu.nl/haddock2.4/library).
+A full list of supported ions can be found [here](./supported_particles.md#supported-ions).
 
 **Note:** Most of the tasks mentioned above can also be performed using our PDB-tools python scripts ([Rodrigues et al. *F1000 Research* (2018)](https://doi.org/10.12688/f1000research.17456.1)) to manipulate PDB files, select and rename chains and segids, renumber residues... and much more!
 It should be installed by default in your haddock3 environment.
@@ -84,9 +84,9 @@ Note that if in your ensemble, we detect two types of `REMARK` statements when p
 
 ## Dealing with non-standard molecules
 
-If you wish to work with a molecule type that is not present in the [list of supported molecules](https://wenmr.science.uu.nl/haddock2.4/library), do not worry, as you will still be able to use HADDOCK.
-To properly function, HADDOCK requires to have access to the topology and parameters of a molecule to run the molecular dynamics protocols.
-The force field must therefore be updated by user-provided topology and parameter files.
+If you wish to work with a molecule type that is not present in the [supported particles list](./supported_particles.md), do not worry, as you will still be able to use HADDOCK.
+One way to do this is to use the `autotoppar` option in the `[topoaa]` module, which will try to automatically generate the topology and parameters using PRODRG.
+If this is not possible, you will have to provide the topology and parameters yourself.To properly function, HADDOCK requires to have access to the topology and parameters of a molecule to run the molecular dynamics protocols. The force field must therefore be updated by user-provided topology and parameter files.
 
 In modules that use CNS, you can provide such files with the `ligand_top_fname` (for ligand topology filename) and `ligand_param_fname` (for ligand parameters filename) parameters, specifying the location where to find those two files.
 

--- a/src/structure_requirements.md
+++ b/src/structure_requirements.md
@@ -86,7 +86,9 @@ Note that if in your ensemble, we detect two types of `REMARK` statements when p
 
 If you wish to work with a molecule type that is not present in the [supported particles list](./supported_particles.md), do not worry, as you will still be able to use HADDOCK.
 One way to do this is to use the `autotoppar` option in the `[topoaa]` module, which will try to automatically generate the topology and parameters using PRODRG.
-If this is not possible, you will have to provide the topology and parameters yourself.To properly function, HADDOCK requires to have access to the topology and parameters of a molecule to run the molecular dynamics protocols. The force field must therefore be updated by user-provided topology and parameter files.
+If this is not possible, you will have to provide the topology and parameters yourself. 
+To properly function, HADDOCK requires to have access to the topology and parameters of a molecule to run the molecular dynamics protocols. 
+The force field must therefore be updated by user-provided topology and parameter files.
 
 In modules that use CNS, you can provide such files with the `ligand_top_fname` (for ligand topology filename) and `ligand_param_fname` (for ligand parameters filename) parameters, specifying the location where to find those two files.
 

--- a/src/supported_particles.md
+++ b/src/supported_particles.md
@@ -1,0 +1,173 @@
+# List of supported particles
+Haddock3 supports (i.e., can process automatically including topology generation, rebuilding of the missing atoms, and point mutations) various carbohydrates, ions, co-factors and a plethora of the modified amino acids - you can check a complete list below.
+
+### Supported carbohydrates
+* A2G: 2-N-acetyl-alpha-D-glucopyranose, different stereochemistry at C4
+* ABE: alpha-D-Abequopyranose
+* BDP: beta-D-glucoronic acid
+* BGC: beta-D-glucopyranose
+* BMA: beta-D-mannopyronose
+* FCA: alpha-D-fucopyranose
+* FCB: beta-D-fucopyranose
+* FUC: alpha-L-fucopyranose
+* FUL: beta-L-fucopyranose
+* GAL (GLB): beta-D-galactopyranose
+* GLA: alpha-D-galactopyranose
+* GLC: alpha-D-glucopyranose
+* GCS: 2-N-beta-D-glucopyranose (glucosamine)
+* GXL: alpha-L-galactopyranose
+* MAG: 2-N-Acetyl-beta-D-glucopyranose + Methyl at O1
+* MAN: alpha-D-mannopyranose
+* MMA: methyl alpha-D-mannopyranoside
+* NAA: 1-O-methyl-2-N-Acetyl-alpha-D-glucopyranose
+* NAG: 2-N-acetyl-beta-D-glucopyranose
+* NAM: 1-O-methyl-2-N-Acetyl-beta-D-glucopyranose
+* NDG: 2-N-acetyl-alpha-D-glucopyranose
+* NGA: 2-N-acetyl-beta-D-galactopyranose
+* NGM: 1-O-methyl-2-N-Acetyl-alpha-D-galactopyranose
+* RAM: alpha-L-rhampyranose
+* SIA: alpha-N-acetyl neuraminic acid
+* SIB: beta-N-acetyl neuraminic acid
+* XYP: beta-D-xylopyranose
+* XYS: alpha-D-xylopyranose
+
+Carbohydrates should be provided with record **HETAM**, e.g.:
+```
+HETATM    9  C1  NAG B 102     171.992  99.750 236.168  1.00 10.00           C
+```
+
+### Supported ions
+| | | |
+| --- | --- | --- |
+| AG: Silver | AL: Aluminium | AU: Gold |
+| BR: Bromine | CA: Calcium | CD: Cadmium |
+| CL: Chlore | CO: Cobalt | CR: Chromium |
+| CS: Cesium | CU: Copper | F: Fluor |
+| FE: Iron | HG: Mercury | HO: Holmium |
+| I: Iodine | IR: IridiumP | K: Potassium |
+| KR: Krypton | LI: Adenine | MG: Magnesium |
+| MN: Manganese | MO: Molybdenum | NA: Sodium |
+| NI: Nickel | OS: Osmium | PB: Lead |
+| PT: Platinum | SR: Strontium | U: Uranium |
+| V: Vanadium | YB: Ytterbium | ZN: Zinc |
+
+Ions should be provided with their charge and a **HETAM** flag. Residue name should contain the absolute charge (e.g. ZN2) while atom name should have the exact charge (e.g. ZN+2), e.g.:
+```
+HETATM 3833 ZN+2 ZN2 A  42      21.391  -8.794  33.944  1.00 24.37          ZN  
+```
+
+## Supported multi-atom ions 
+* PO4: Phosphate
+* SO4: Sulphate
+* WO4: Tungstate
+
+## Supported water molecules
+* TIP/WAT: water molecule with as atoms OH2,H1,H2
+
+## Supported co-factors
+The following co-factors are defined using HADDOCK's internal parameters:
+* HEB: Heme B, [open pdb example](https://raw.githubusercontent.com/haddocking/haddock3/refs/heads/main/src/haddock/cns/toppar/hemeB.pdb)
+* HEC: Heme C, [open pdb example](https://raw.githubusercontent.com/haddocking/haddock3/refs/heads/main/src/haddock/cns/toppar/heme.pdb)
+
+Co-factors should be provided with record **HETAM**, e.g.:
+```
+HETATM    1  FE  HEB   500       3.565   0.487   0.949  1.00 15.00          
+```
+For the other co-factors, HADDOCK3 will try to generate the topology and parameters automatically, using the PRODRG server - do add `autotoppar = true` to the `[topoaa]` to enable this option. 
+If the co-factor is not available in PRODRG, you will have to [generate and provide the topology and parameters yourself](../structure_requirements.md#dealing-with-non-standard-molecules).
+
+## Supported nucleic acid bases
+| DNA | RNA |
+| --- | --- |
+| DA: Adenine | A: Adenine |
+| DC: Cytosine | C: Cytosine |
+| DG: Guanine | G: Guanine |
+| DT: Thymidine | U: Uridine |
+
+## Supported modified amino acids
+All supported modified amino acids are in this list and must be defined as **ATOM**. 
+
+* **ACE**: N-terminal acetyl group.
+
+    Atoms: CA,HA1,HA2,HA3,C,O
+* **ALY**: Acetylated LYS.
+
+    Atoms: N,HN,CA,HA,CB,HB1,HB2,CG,HG1,HG2,CD,HD1,HD2,CE1,HE1,HE2,NZ,HZ1,CZ,OZ,CM,HM1,HM2,HM3,C,O
+* **ASH**: protonated ASP.
+
+    Atoms: N,HN,CA,HA,CB,HB1,HB2,CG,OD1,OD2,HD2,C,O
+* **CFE**: CYS with an iron sulfur cluster. HADDOCK will automatically search for closeby CYF residues and created bonds with the iron cluster.
+
+    Atoms: N,HN,CA,HA,CB,HB1,HB2,SG,FE1,SF1,FE2,SF2,C,O
+* **CSP**: phosphorylated CYS.
+
+    Atoms: N,HN,CA,HA,CB,HB1,HB2,SG,P,O1P,O2P,O3P,C,O
+* **CTN**: C-terminal amide group.
+
+    Atoms: N,H1,H2
+* **CYC**: special for covalent docking - vdw of Sulphur reduced.
+
+    Atoms: N,HN,CA,HA,CB,HB1,HB2,SG,C,O
+* **CYF**: CYS without the sulfur H (for coordinating metals).
+
+    Atoms: N,HN,CA,HA,CB,HB1,HB2,SG,C,O
+* **CYM**: CYS with MTSL grouped.
+
+    Atoms: CAC,CAS,CAD,NAQ,OAH,HAA,CAR,CAA,CAB,CAI,CAO,CAJ,SAL,N,HN,CA,HA,CB,HB1,HB2,SG,C,O
+* **DDZ**: 3,3,-dihydroxy ALA.
+
+    Atoms: N,HN,CA,HA,CB,HB1,OG1,HG1,OG2,HG2
+* **GLH**: protonated GLU.
+
+    Atoms: N,HN,CA,HA,CB,HB1,HB2,CG,HG1,HG2,CD,OE1,OE2,HE2,C,O
+* **HY3**: 3-hydroxyproline.
+
+    Atoms: N,CA,HA,CB,OB1,HB1,HB2,CG,HG1,HG2,CD,HD1,HD2,C,O
+* **HYP**: 4R-hydroxyproline.
+
+    Atoms: N,CA,HA,CB,HB1,HB2,CG,OG1,HG1,HG2,CD,HD1,HD2,C,O
+* **M3L**: trimethyl LYS.
+
+    Atoms: N,HN,CA,HA,CB,HB1,HB2,CG,HG1,HG2,CD,HD1,HD2,CE1,HE1,HE2,NZ,HZ1,HZ2,CM1,HM11,HM12,HM13,CM2,HM21,HM22,HM23,CM3,HM31,HM32,HM33,C,O
+* **MLY**: dimethyl LYS.
+
+    Atoms: N,HN,CA,HA,CB,HB1,HB2,CG,HG1,HG2,CD,HD1,HD2,CE1,HE1,HE2,NZ,HZ1,HZ2,CM2,HM21,HM22,HM23,CM3,HM31,HM32,HM33,C,O
+* **MLZ**: monomethyl LYS.
+
+    Atoms: N,HN,CA,HA,CB,HB1,HB2,CG,HG1,HG2,CD,HD1,HD2,CE1,HE1,HE2,NZ,HZ1,HZ2,CM3,HM31,HM32,HM33,C,O
+* **MSE**: Selenomethionine.
+
+    Atoms: N,HN,CA,HA,CB,HB1,HB2,CG,HG1,HG2,SE,CE,HE1,HE2,HE3,C,O
+* **NEP**: NE phosphorylated HIS.
+
+    Atoms: N,HN,CA,HA,CB,HB1,HB2,CG,ND1,HD1,CD2,HD2,CE1,HE1,NE2,P,O1P,O2P,O3P,C,O
+* **NME**: C-terminal N-Methyl.
+
+    Atoms: N,HN,CA,HA1,HA2,HA3
+* **PNS**: Phosphopanthetine Serine.
+
+    Atoms: N,HN,CA,HA,CB,HB1,HB2,OG,P,O1P,O2P,O3P,C,O,C28,H28,H29,C29,C30,H31,H32,H30,C31,H34,H35,H33,C32,H36,O33,H46,C34,O35,N36,H48,C37,H37,H38,C38,H39,H4A,C39,O40,N41,H41,C42,H42,H43,C43,H44,H45,S44,H47
+* **PTR**: O-Phosphotyrosine.
+
+    Atoms: N,CA,C,O,OXT,CB,CG,CD1,CD2,CE1,CE2,CZ,OH,P,O1P,O2P,O3P,1HN,2HN,HA,HXT,1HB,2HB,HD1,HD2,HE1,HE2,PHO2,PHO3
+* **SEC**: Serine with reduced vdw on the OG oxygen for covalent docking.
+
+    Atoms: N,HN,CA,HA,CB,HB1,HB2,OG,C,O
+* **SEP**: phosphorylated SER.
+
+    Atoms: N,HN,CA,HA,CB,HB1,HB2,OG,P,O1P,O2P,O3P,C,O
+* **TOP**: phosphorylated THR.
+
+    Atoms: N,HN,CA,HA,CB,HB1,HB2,OG,P,O1P,O2P,O3P,CG2,HG21,HG22,HG23,C,O
+* **TYP** or **PTR**: phosphorylated TYR.
+
+    Atoms: N,HN,CA,HA,CB,HB1,HB2,CG,CD1,HD1,CD2,HD2,CE1,HE1,CE2,HE2,CZ,OH,P,O1P,O2P,O3P,C,O
+* **TYS**: sulfonated TYR.
+
+    Atoms: N,HN,CA,HA,CB,HB1,HB2,CG,CD1,HD1,CD2,HD2,CE1,HE1,CE2,HE2,CZ,OH,S,O1S,O2S,O3S,C,O
+* **QSR**: serotonylated GLN.
+
+    Atoms: N,HN,CA,HA,CB,HB1,HB2,CG,HG1,HG2,CD,OE1,NE2,HE2,CSA,HSA1,HSA2,CSB,HSB1,HSB2,HSE1,NSE1,CSD1,HSD1,CSG,CSD2,CSE2,CSE3,HSE3,CSZ3,OSZ3,HSZ3,CSH2,HSH2,CSZ2,HSZ2,C,O,
+* **PCA**: pyro-glutamic acid.
+
+    Atoms: N,HN,CA,HA,CB,HB1,HB2,CG,HG1,HG2,CD,OE,C,O

--- a/src/supported_particles.md
+++ b/src/supported_particles.md
@@ -74,7 +74,7 @@ Co-factors should be provided with record **HETAM**, e.g.:
 HETATM    1  FE  HEB   500       3.565   0.487   0.949  1.00 15.00          
 ```
 For the other co-factors, HADDOCK3 will try to generate the topology and parameters automatically, using the PRODRG server - do add `autotoppar = true` to the `[topoaa]` to enable this option. 
-If the co-factor is not available in PRODRG, you will have to [generate and provide the topology and parameters yourself](../structure_requirements.md#dealing-with-non-standard-molecules).
+If the co-factor is not available in PRODRG, you will have to [generate and provide the topology and parameters yourself](./structure_requirements.md#dealing-with-non-standard-molecules).
 
 ## Supported nucleic acid bases
 | DNA | RNA |


### PR DESCRIPTION
Before this PR, haddock3 user manual was pointing to HADDOCK2.4 library [here](https://wenmr.science.uu.nl/haddock2.4/library) every time supported list was mentioned. That is not too nice, and since we comit to better documentation within BioExcel-3 - this PR adds a list of supported partciles directly to the user manual. 

I tried to fish out all links to HADDOCK2.4 library from this manual - should’ve get them all + edited text around those links when saw that things can be improved.